### PR TITLE
Add Makefile and testing docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	 npm test

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Anasonix is a website project built using modern web technologies. This reposito
 2. **Deploy**
    Upload the contents of `dist/` to your preferred hosting provider (e.g., Netlify, Vercel, or a traditional web server).
 
+## Running Tests
+
+Use the provided `Makefile` to run any project tests.
+
+```bash
+make test
+```
+
+This command simply invokes `npm test`.
+
 ## Technologies Used
 
 - **Tailwind CSS** for utility-first styling.


### PR DESCRIPTION
## Summary
- add a simple `Makefile` with `test` target
- document how to run tests using `make test` in the README

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688afb5568708327810827a253c21534