### PR TITLE
Add about page for Anasonix

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About Anasonix</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+</head>
+<body>
+  <nav class="navbar navbar-default">
+    <div class="container-fluid">
+      <div class="navbar-header">
+        <a class="navbar-brand" href="index.html">Anasonix</a>
+      </div>
+      <ul class="nav navbar-nav navbar-right">
+        <li class="active"><a href="#">About</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-12">
+        <h1 class="text-center">About Anasonix</h1>
+        <hr>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-4 text-center">
+        <img src="images/anasonix_logo.png" alt="Anasonix Logo" class="img-responsive center-block" style="max-width:200px;">
+      </div>
+      <div class="col-sm-8">
+        <h2>Anas Mangla</h2>
+        <p>Anas Mangla is a technology enthusiast and entrepreneur dedicated to building secure, user-friendly web solutions. With a passion for clean code and modern design, Anas founded Anasonix to help businesses thrive online.</p>
+        <p><strong>Mission:</strong> Anasonix aims to deliver accessible digital experiences that combine robust security with beautiful design. By leveraging open technologies, the company provides tools and services that empower small businesses and creators to succeed on the web.</p>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-12">
+        <h2 class="m-t-40">Location</h2>
+        <p>Naz716 Business Center<br>123 Example Street<br>Lahore, Pakistan</p>
+        <div class="embed-responsive embed-responsive-16by9">
+          <iframe class="embed-responsive-item" src="https://www.google.com/maps?q=Naz716+Business+Center&output=embed" allowfullscreen></iframe>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-12">
+        <h2 class="m-t-40">Our Team</h2>
+        <p>Details about the Anasonix team are coming soon.</p>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `about.html` with a short biography of Anas Mangla
- describe the mission of Anasonix
- mention the Naz716 Business Center location and embed a Google map
- include a placeholder for team info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b05dbb7cc8327883cb780ea314ce5